### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Next, you need to install developer components, which are OS-specific:
   brew install cmake pkg-config
   ```
 
-* Windows: download and install the latest [Visual Studio Redistributable][VS]
+* Windows: download and install the latest [Build Tools for Visual Studio](https://aka.ms/vs/17/release/vs_BuildTools.exe), including the 'Desktop development with C++' workflow and recommended optional features
 
 Finally, install RGB command-line utility shipped with this repo by running
 ```


### PR DESCRIPTION
VS Redistributable is not the only prereq, the build tools that come with a full Visual Studio installation are also required, as well as most of the recommended optional features. This is not noticeable on the developer's machine, only reproducible from a fresh one. 

I have attached a log for proof. 
[Error log, post-discovery & pre-fix](https://github.com/RGB-WG/rgb/files/11239739/log.txt)
Excerpt:
```
error: linker `link.exe` not found
  |
  = note: program not found

note: the msvc targets depend on the msvc linker but `link.exe` was not found

note: please ensure that Visual Studio 2017 or later, or Build Tools for Visual Studio were installed with the Visual C++ option.

note: VS Code is a different product, and is not sufficient.
```
https://stackoverflow.com/questions/55603111/unable-to-compile-rust-hello-world-on-windows-linker-link-exe-not-found


[This was my powershell script to setup RGB on windows](https://github.com/RGB-WG/rgb/files/11239953/rgbsetup.ps1.txt) (drop the .txt extension)

This can be slimmed down with msys2 if I understand correctly. Will be investigating.
