### PR TITLE
fix: get correct server parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 **/*.rs.bk
 
 .idea
+.vscode
 
 *.swp
 

--- a/src/bin/rgb/main.rs
+++ b/src/bin/rgb/main.rs
@@ -69,7 +69,9 @@ fn run() -> Result<(), RuntimeError> {
     LogLevel::from_verbosity_flag_count(opts.verbose).apply();
     trace!("Command-line arguments: {:#?}", &opts);
 
-    let electrum = opts.electrum.unwrap_or(opts.chain.default_resolver());
+    let electrum = opts
+        .electrum
+        .unwrap_or_else(|| opts.chain.default_resolver());
 
     let mut runtime = Runtime::load(opts.data_dir.clone(), opts.chain, &electrum)?;
     debug!("Executing command: {}", opts.command);


### PR DESCRIPTION
When I tried use rgb-cli with `--electrum localhost:50001 --chain regtest` options, the follow error occurs:

```
thread 'main' panicked at 'no default server is known for regtest, please provide a custom URL', src/wallet.rs:124:21
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

I found the reason here: https://stackoverflow.com/a/56726618


This PR fix that!