### PR TITLE
add default resolver for regtest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,9 +65,9 @@ serde = "1.0.159"
 serde_yaml = "0.9.19"
 
 [features]
-default = []
+default = ["electrum", "log"]
 all = ["cli", "log"]
-electrum = ["electrum-client"]
+electrum = ["electrum-client", "log"]
 cli = ["clap", "shellexpand", "log", "electrum"]
 
 [package.metadata.docs.rs]

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -120,6 +120,7 @@ mod _electrum {
             match self {
                 Chain::Bitcoin => s!("blockstream.info:110"),
                 Chain::Testnet3 => s!("blockstream.info:143"),
+                Chain::Regtest => s!("localhost:50001"),
                 chain => {
                     panic!("no default server is known for {chain}, please provide a custom URL")
                 }


### PR DESCRIPTION
this small PR adds a default electrum resolver for the `Regtest` network in the `default_resolver` function