### PR TITLE
add set-host command

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
           - cli
           - electrum
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install rust stable
         uses: actions-rs/toolchain@v1
         with:
@@ -56,7 +56,7 @@ jobs:
       matrix:
         os: [ ubuntu-20.04, ubuntu-22.04, macos-11, macos-12, windows-2019, windows-2022 ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install rust stable
         uses: actions-rs/toolchain@v1
         with:
@@ -74,7 +74,7 @@ jobs:
       matrix:
         toolchain: [ nightly, beta, stable, 1.66.0 ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install rust ${{ matrix.toolchain }}
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -13,7 +13,7 @@ jobs:
   codecov:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install latest nightly
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
   fmt:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install rustc nightly
         uses: actions-rs/toolchain@v1
         with:
@@ -28,7 +28,7 @@ jobs:
   clippy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install rustc stable
         uses: actions-rs/toolchain@v1
         with:
@@ -43,7 +43,7 @@ jobs:
   doc:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install rustc nightly
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
   testing:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install latest stable
         uses: actions-rs/toolchain@v1
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -370,9 +370,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e3c5919066adf22df73762e50cffcde3a758f2a848b113b586d1f86728b673b"
 dependencies = [
  "iana-time-zone",
+ "js-sys",
  "num-integer",
  "num-traits",
  "serde",
+ "time 0.1.45",
+ "wasm-bindgen",
  "winapi",
 ]
 
@@ -670,7 +673,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "wasm-bindgen",
 ]
 
@@ -888,6 +891,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
 
 [[package]]
+name = "percent-encoding"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1032,8 +1041,7 @@ dependencies = [
 [[package]]
 name = "rgb-std"
 version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "789fe6ac20c5ef10dbb3a016d0076168daeef4cb9a77c4ae2445c6c051564872"
+source = "git+https://github.com/RGB-WG/rgb-wallet?branch=master#43ce84bf4756c1a7269d1215e5b1b92d8b58f8da"
 dependencies = [
  "amplify",
  "baid58",
@@ -1051,17 +1059,18 @@ dependencies = [
 [[package]]
 name = "rgb-wallet"
 version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db48e353327bcfbdfaa578408da1960c6a3409628b1917679e010aba4a3637ac"
+source = "git+https://github.com/RGB-WG/rgb-wallet?branch=master#43ce84bf4756c1a7269d1215e5b1b92d8b58f8da"
 dependencies = [
  "amplify",
  "baid58",
  "bitcoin",
  "bp-core",
+ "chrono",
  "commit_verify",
  "fluent-uri",
  "getrandom",
  "indexmap",
+ "percent-encoding",
  "rgb-core",
  "rgb-std",
  "strict_encoding",
@@ -1255,7 +1264,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with_macros",
- "time",
+ "time 0.3.20",
 ]
 
 [[package]]
@@ -1426,6 +1435,17 @@ dependencies = [
 
 [[package]]
 name = "time"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
+dependencies = [
+ "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
+ "winapi",
+]
+
+[[package]]
+name = "time"
 version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd0cbfecb4d19b5ea75bb31ad904eb5b9fa13f21079c3b92017ebdf4999a5890"
@@ -1535,6 +1555,12 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "wasi"
+version = "0.10.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,3 +72,7 @@ cli = ["clap", "shellexpand", "log", "electrum"]
 
 [package.metadata.docs.rs]
 features = [ "all" ]
+
+[patch.crates-io]
+rgb-std = { git = "https://github.com/RGB-WG/rgb-wallet", branch = "master", features = ["fs"] }
+rgb-wallet = { git = "https://github.com/RGB-WG/rgb-wallet", branch = "master", features = ["fs"] }

--- a/src/bin/rgb/command.rs
+++ b/src/bin/rgb/command.rs
@@ -505,14 +505,15 @@ impl Command {
                 let iface = TypeName::try_from(iface).expect("invalid interface name");
                 let seal = GraphSeal::from(seal);
                 let invoice = RgbInvoice {
-                    transport: RgbTransport::UnspecifiedMeans,
-                    contract: contract_id,
-                    iface,
+                    transports: vec![RgbTransport::UnspecifiedMeans],
+                    contract: Some(contract_id),
+                    iface: Some(iface),
                     operation: None,
                     assignment: None,
                     beneficiary: seal.to_concealed_seal().into(),
                     owned_state: TypedState::Amount(value),
                     chain: None,
+                    expiry: None,
                     unknown_query: none!(),
                 };
                 runtime.store_seal_secret(seal)?;

--- a/src/bin/rgb/command.rs
+++ b/src/bin/rgb/command.rs
@@ -34,6 +34,8 @@ use rgbstd::interface::{ContractBuilder, SchemaIfaces, TypedState};
 use rgbstd::persistence::{Inventory, Stash};
 use rgbstd::schema::SchemaId;
 use rgbstd::Txid;
+use rgbwallet::psbt::opret::OutputOpret;
+use rgbwallet::psbt::tapret::OutputTapret;
 use rgbwallet::{InventoryWallet, RgbInvoice, RgbTransport};
 use strict_types::encoding::{Ident, TypeName};
 use strict_types::StrictVal;
@@ -207,6 +209,17 @@ pub enum Command {
 
         /// File with the transfer consignment.
         file: PathBuf,
+    },
+
+    /// Set first opret/tapret output to host a commitment
+    #[display("set-host")]
+    SetHost {
+        #[clap(long, default_value = "tapret1st")]
+        /// Method for single-use-seals.
+        method: CloseMethod,
+
+        /// PSBT file.
+        psbt_file: PathBuf,
     },
 }
 
@@ -667,6 +680,49 @@ impl Command {
                 eprintln!("{}", transfer.validation_status().expect("just validated"));
                 runtime.accept_transfer(transfer, force)?;
                 eprintln!("Transfer accepted into the stash");
+            }
+            Command::SetHost { method, psbt_file } => {
+                let psbt_data = fs::read(&psbt_file)?;
+                let mut psbt = Psbt::deserialize(&psbt_data)?;
+                let mut psbt_modified = false;
+                match method {
+                    CloseMethod::OpretFirst => {
+                        psbt
+                            .unsigned_tx
+                            .output
+                            .iter()
+                            .zip(&mut psbt.outputs)
+                            .find(|(o, outp)| {
+                                o.script_pubkey.is_op_return() && !outp.is_opret_host()
+                            })
+                            .and_then(|(_, outp)| {
+                                psbt_modified = true;
+                                outp.set_opret_host().ok()
+                            });
+                    }
+                    CloseMethod::TapretFirst => {
+                        psbt
+                            .unsigned_tx
+                            .output
+                            .iter()
+                            .zip(&mut psbt.outputs)
+                            .find(|(o, outp)| {
+                                o.script_pubkey.is_v1_p2tr() && !outp.is_tapret_host()
+                            })
+                            .and_then(|(_, outp)| {
+                                psbt_modified = true;
+                                outp.set_tapret_host().ok()
+                            });
+                    }
+                    _ => {}
+                };
+                fs::write(&psbt_file, psbt.serialize())?;
+                if psbt_modified {
+                    eprintln!(
+                        "PSBT file '{}' is updated with {method} host now set.",
+                        psbt_file.display()
+                    );
+                }
             }
         }
 


### PR DESCRIPTION
This PR adds the `set-host` command to set `opret`/`tapret` host, if needed.

This is intended to be called by a user that has prepared a PSBT with an output ready for the commitment but needing to set it as a host, via CLI.

This comes from (and depends on) [rgb-wallet PR #46](https://github.com/RGB-WG/rgb-wallet/pull/46), which initially did the same in the `pay` command but now only makes `opret` and `tapret` modules public.