### PR TITLE
Fungible operation history

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1529,8 +1529,7 @@ dependencies = [
 [[package]]
 name = "rgb-core"
 version = "0.11.0-beta.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb0581f9bc33b509400aa9225d2308dfd45af413a4fe38f7c4b823a7e09e6036"
+source = "git+https://github.com/RGB-WG/rgb-core?branch=v0.11#b1232f5f77ff253bbe79bdcee04a2cf0d4ef0c05"
 dependencies = [
  "aluvm",
  "amplify",
@@ -1550,8 +1549,7 @@ dependencies = [
 [[package]]
 name = "rgb-invoice"
 version = "0.11.0-beta.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4898f1ca45d70ed18f3f1977ef35ffe8ee35870c982ad9fb842a6fbaeb512490"
+source = "git+https://github.com/RGB-WG/rgb-std?branch=v0.11#b71d58fd087506746347c68d676b8079e3b751d3"
 dependencies = [
  "amplify",
  "baid58",
@@ -1620,8 +1618,7 @@ dependencies = [
 [[package]]
 name = "rgb-std"
 version = "0.11.0-beta.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bc24f24f2e942d1c20f46a68b331d7864fbdf94ab334c6fac20840816d30a54"
+source = "git+https://github.com/RGB-WG/rgb-std?branch=v0.11#b71d58fd087506746347c68d676b8079e3b751d3"
 dependencies = [
  "amplify",
  "baid58",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1529,7 +1529,7 @@ dependencies = [
 [[package]]
 name = "rgb-core"
 version = "0.11.0-beta.4"
-source = "git+https://github.com/RGB-WG/rgb-core?branch=v0.11#b1232f5f77ff253bbe79bdcee04a2cf0d4ef0c05"
+source = "git+https://github.com/RGB-WG/rgb-core?branch=v0.11#2b59903039770df4766c9681bc74691382308ef5"
 dependencies = [
  "aluvm",
  "amplify",
@@ -1549,7 +1549,7 @@ dependencies = [
 [[package]]
 name = "rgb-invoice"
 version = "0.11.0-beta.4"
-source = "git+https://github.com/RGB-WG/rgb-std?branch=v0.11#b71d58fd087506746347c68d676b8079e3b751d3"
+source = "git+https://github.com/RGB-WG/rgb-std?branch=v0.11#9db17e1a6b08d3817ffeebdfb85a4b405818fec4"
 dependencies = [
  "amplify",
  "baid58",
@@ -1618,7 +1618,7 @@ dependencies = [
 [[package]]
 name = "rgb-std"
 version = "0.11.0-beta.4"
-source = "git+https://github.com/RGB-WG/rgb-std?branch=v0.11#b71d58fd087506746347c68d676b8079e3b751d3"
+source = "git+https://github.com/RGB-WG/rgb-std?branch=v0.11#9db17e1a6b08d3817ffeebdfb85a4b405818fec4"
 dependencies = [
  "amplify",
  "baid58",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,3 +91,8 @@ serde = ["serde_crate", "serde_with", "serde_yaml", "bp-std/serde", "bp-wallet/s
 
 [package.metadata.docs.rs]
 features = [ "all" ]
+
+[patch.crates-io]
+rgb-core = { git = "https://github.com/RGB-WG/rgb-core", branch = "v0.11" }
+rgb-invoice = { git = "https://github.com/RGB-WG/rgb-std", branch = "v0.11" }
+rgb-std = { git = "https://github.com/RGB-WG/rgb-std", branch = "v0.11" }

--- a/cli/src/command.rs
+++ b/cli/src/command.rs
@@ -439,7 +439,7 @@ impl Exec for RgbArgs {
                         for allocation in allocations {
                             println!(
                                 "    amount={}, utxo={}, witness={} # owned by the wallet",
-                                allocation.value, allocation.owner, allocation.witness
+                                allocation.state, allocation.seal, allocation.witness
                             );
                         }
                     }
@@ -450,7 +450,7 @@ impl Exec for RgbArgs {
                             for allocation in allocations {
                                 println!(
                                     "    amount={}, utxo={}, witness={} # owner unknown",
-                                    allocation.value, allocation.owner, allocation.witness
+                                    allocation.state, allocation.seal, allocation.witness
                                 );
                             }
                         }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -126,7 +126,7 @@ impl<D: DescriptorRgb<K>, K> DerefMut for Runtime<D, K> {
 }
 
 impl<D: DescriptorRgb<K>, K> OutpointFilter for Runtime<D, K> {
-    fn include_output(&self, output: impl Into<XOutpoint>) -> bool {
+    fn include_outpoint(&self, output: impl Into<XOutpoint>) -> bool {
         let output = output.into();
         self.wallet()
             .coins()
@@ -140,9 +140,9 @@ pub struct ContractOutpointsFilter<'runtime, D: DescriptorRgb<K>, K> {
 }
 
 impl<'runtime, D: DescriptorRgb<K>, K> OutpointFilter for ContractOutpointsFilter<'runtime, D, K> {
-    fn include_output(&self, output: impl Into<XOutpoint>) -> bool {
+    fn include_outpoint(&self, output: impl Into<XOutpoint>) -> bool {
         let output = output.into();
-        if !self.filter.include_output(output) {
+        if !self.filter.include_outpoint(output) {
             return false;
         }
         matches!(self.filter.stock.state_for_outpoints(self.contract_id, [output]), Ok(list) if !list.is_empty())

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -21,6 +21,7 @@
 
 #![allow(clippy::result_large_err)]
 
+use std::collections::HashMap;
 use std::convert::Infallible;
 use std::io;
 use std::io::ErrorKind;
@@ -32,12 +33,16 @@ use bpstd::{Network, XpubDerivable};
 use bpwallet::Wallet;
 use rgbfs::StockFs;
 use rgbstd::containers::{Contract, LoadError, Transfer};
-use rgbstd::interface::{BuilderError, OutpointFilter};
-use rgbstd::persistence::{Inventory, InventoryDataError, InventoryError, StashError, Stock};
+use rgbstd::interface::{
+    AmountChange, BuilderError, ContractError, IfaceOp, OutpointFilter, WitnessFilter,
+};
+use rgbstd::persistence::{
+    Inventory, InventoryDataError, InventoryError, Stash, StashError, Stock,
+};
 use rgbstd::resolvers::ResolveHeight;
 use rgbstd::validation::{self, ResolveWitness};
-use rgbstd::{ContractId, XChain, XOutpoint};
-use strict_types::encoding::{DecodeError, DeserializeError, Ident, SerializeError};
+use rgbstd::{AssignmentWitness, ContractId, WitnessId, XChain, XOutpoint};
+use strict_types::encoding::{DecodeError, DeserializeError, Ident, SerializeError, TypeName};
 
 use crate::{DescriptorRgb, RgbDescr};
 
@@ -66,6 +71,12 @@ pub enum RuntimeError {
 
     #[from]
     Builder(BuilderError),
+
+    #[from]
+    History(HistoryError),
+
+    #[from]
+    Contract(ContractError),
 
     #[from]
     PsbtDecode(psbt::DecodeError),
@@ -111,6 +122,7 @@ impl From<Infallible> for RuntimeError {
 pub struct Runtime<D: DescriptorRgb<K> = RgbDescr, K = XpubDerivable> {
     stock_path: PathBuf,
     #[getter(as_mut)]
+    // TODO: Parametrize by the stock
     stock: Stock,
     bprt: bpwallet::Runtime<D, K /* TODO: Add layer 2 */>,
 }
@@ -131,6 +143,16 @@ impl<D: DescriptorRgb<K>, K> OutpointFilter for Runtime<D, K> {
         self.wallet()
             .coins()
             .any(|utxo| XChain::Bitcoin(utxo.outpoint) == output)
+    }
+}
+
+impl<D: DescriptorRgb<K>, K> WitnessFilter for Runtime<D, K> {
+    fn include_witness(&self, witness: impl Into<AssignmentWitness>) -> bool {
+        let witness = witness.into();
+        self.wallet()
+            .transactions()
+            .keys()
+            .any(|txid| AssignmentWitness::Present(WitnessId::Bitcoin(*txid)) == witness)
     }
 }
 
@@ -234,4 +256,41 @@ impl<D: DescriptorRgb<K>, K> Runtime<D, K> {
             .accept_transfer(transfer, resolver, force)
             .map_err(RuntimeError::from)
     }
+
+    // TODO: Integrate into BP Wallet `TxRow` as L2 and provide transactional info
+    pub fn fungible_history(
+        &self,
+        contract_id: ContractId,
+        iface_name: impl Into<TypeName>,
+    ) -> Result<HashMap<WitnessId, IfaceOp<AmountChange>>, RuntimeError> {
+        let iface_name = iface_name.into();
+        let iface = self.stock.iface_by_name(&iface_name)?;
+        let default_op = iface
+            .default_operation
+            .as_ref()
+            .ok_or(HistoryError::NoDefaultOp)?;
+        let state_name = iface
+            .transitions
+            .get(default_op)
+            .ok_or(HistoryError::DefaultOpNotTransition)?
+            .default_assignment
+            .as_ref()
+            .ok_or(HistoryError::NoDefaultAssignment)?
+            .clone();
+        let contract = self.stock.contract_iface_named(contract_id, iface_name)?;
+        contract
+            .fungible_ops::<AmountChange>(state_name, self, self)
+            .map_err(RuntimeError::from)
+    }
+}
+
+#[derive(Debug, Display, Error, From)]
+#[display(doc_comments)]
+pub enum HistoryError {
+    /// interface doesn't define default operation
+    NoDefaultOp,
+    /// default operation defined by the interface is not a state transition
+    DefaultOpNotTransition,
+    /// interface doesn't define default fungible state
+    NoDefaultAssignment,
 }


### PR DESCRIPTION
The PR for the first time provides an ability for a runtime to reconstruct operation history for any fungible asset (not just RGB20, but under any interface) out of stash data (plus wallet information) - and print it out via cli command `fungible-history`.