### PR TITLE
invoice error for blind with no outpoint

### DIFF
--- a/cli/src/command.rs
+++ b/cli/src/command.rs
@@ -670,7 +670,12 @@ impl Exec for RgbArgs {
                     .next();
                 let network = runtime.wallet().network();
                 let beneficiary = match (address_based, outpoint) {
-                    (true, _) | (false, None) => {
+                    (false, None) => {
+                        return Err(RuntimeError::Custom(s!(
+                            "blinded invoice requested but no suitable outpoint is available"
+                        )));
+                    }
+                    (true, _) => {
                         let addr = runtime
                             .wallet()
                             .addresses(RgbKeychain::Rgb)


### PR DESCRIPTION
This PR returns an error instead of silently switching to address-based mode when a blinded invoice is requested (no `-a` option specified) but no suitable outpoint is found.

The rationale for this is that a user can request a blinded invoice and fail to notice what the command returned is instead an address-based one. This might be the case if, as an example, the wallet had available UTXOs on keychain `0` but not on `9`.