### PR TITLE
bp-wallet default-features false

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ strict_types = "1.6.3"
 bp-core = "0.11.0-beta.3"
 bp-seals = "0.11.0-beta.3"
 bp-std = "0.11.0-beta.3"
-bp-wallet = "0.11.0-beta.4"
+bp-wallet = { version = "0.11.0-beta.4", default-features = false }
 bp-util = "0.11.0-beta.4"
 bp-esplora = "0.11.0-beta.2"
 descriptors = "0.11.0-beta.3"
@@ -70,7 +70,7 @@ commit_verify = { workspace = true }
 strict_types = { workspace = true }
 bp-core = { workspace = true }
 bp-std = { workspace = true }
-bp-wallet = { workspace = true, features = ["fs"] }
+bp-wallet = { workspace = true, default-features = false, features = ["fs"] }
 bp-esplora = { workspace = true, optional = true }
 descriptors = { workspace = true }
 rgb-std = { workspace = true }


### PR DESCRIPTION
By adding `bp-wallet` to the dependencies without specifying `default-features = false` we are also importing `bp-esplora` (because `bp-wallet` specifies `default = ["esplora"]`), making the `rgb-runtime` definition of the `esplora` feature (`esplora = ["bp-esplora", "bp-wallet/esplora"]`) pointless.
With this PR we import `bp-wallet` without default features, allowing users of `rgb-runtime` to avoid depending on `bp-esplora` unconditionally.