### PR TITLE
complete electrum support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -467,10 +467,11 @@ dependencies = [
 [[package]]
 name = "bp-util"
 version = "0.11.0-beta.4"
-source = "git+https://github.com/BP-WG/bp-wallet?branch=master#8552e161d4b0f1115df4b5cd14e69257e7efead7"
+source = "git+https://github.com/BP-WG/bp-wallet?branch=master#690d8f6bfe76f0f6cd8dbb0039368b1b9fcf45e7"
 dependencies = [
  "amplify",
  "base64",
+ "bp-electrum",
  "bp-esplora",
  "bp-std",
  "bp-wallet",
@@ -489,15 +490,17 @@ dependencies = [
 [[package]]
 name = "bp-wallet"
 version = "0.11.0-beta.4"
-source = "git+https://github.com/BP-WG/bp-wallet?branch=master#8552e161d4b0f1115df4b5cd14e69257e7efead7"
+source = "git+https://github.com/BP-WG/bp-wallet?branch=master#690d8f6bfe76f0f6cd8dbb0039368b1b9fcf45e7"
 dependencies = [
  "amplify",
+ "bp-electrum",
  "bp-esplora",
  "bp-std",
  "cfg_eval",
  "descriptors",
  "psbt",
  "serde",
+ "serde_json",
  "serde_with",
  "serde_yaml",
  "toml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,7 +89,7 @@ log = { workspace = true, optional = true }
 default = ["esplora_blocking"]
 all = ["esplora_blocking", "electrum", "serde", "log"]
 esplora_blocking = ["bp-esplora", "bp-wallet/esplora"]
-electrum = ["bp-electrum"]
+electrum = ["bp-electrum", "bp-wallet/electrum"]
 serde = ["serde_crate", "serde_with", "serde_yaml", "bp-std/serde", "bp-wallet/serde", "descriptors/serde", "rgb-psbt/serde"]
 
 [package.metadata.docs.rs]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -27,7 +27,7 @@ bp-wallet = { workspace = true }
 bp-util = { workspace = true }
 psbt = { workspace = true }
 rgb-std = { workspace = true, features = ["serde"] }
-rgb-runtime = { version = "0.11.0-beta.1", path = "..", features = ["esplora_blocking", "log", "serde"] }
+rgb-runtime = { version = "0.11.0-beta.1", path = "..", features = ["electrum", "esplora_blocking", "log", "serde"] }
 log = { workspace = true }
 env_logger = "0.10.1"
 clap = { version = "4.4.8", features = ["derive", "env"] }

--- a/src/resolvers/any.rs
+++ b/src/resolvers/any.rs
@@ -19,6 +19,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use rgbstd::containers::Consignment;
 use rgbstd::resolvers::ResolveHeight;
 use rgbstd::validation::{ResolveWitness, WitnessResolverError};
 use rgbstd::{WitnessAnchor, WitnessId, XAnchor, XPubWitness};
@@ -45,6 +46,18 @@ pub enum AnyResolver {
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, Display, Error, From)]
 #[display(doc_comments)]
+pub enum AnyResolverError {
+    #[cfg(feature = "electrum")]
+    #[display(inner)]
+    Electrum(::electrum::Error),
+    #[cfg(feature = "esplora_blocking")]
+    #[display(inner)]
+    Esplora(esplora::Error),
+}
+
+#[allow(clippy::large_enum_variant)]
+#[derive(Debug, Display, Error, From)]
+#[display(doc_comments)]
 pub enum AnyAnchorResolverError {
     #[cfg(feature = "electrum")]
     #[from]
@@ -54,6 +67,17 @@ pub enum AnyAnchorResolverError {
     #[from]
     #[display(inner)]
     Esplora(esplora_blocking::AnchorResolverError),
+}
+
+impl AnyResolver {
+    pub fn add_terminals<const TYPE: bool>(&mut self, consignment: &Consignment<TYPE>) {
+        match self {
+            #[cfg(feature = "electrum")]
+            AnyResolver::Electrum(inner) => inner.add_terminals(consignment),
+            #[cfg(feature = "esplora_blocking")]
+            AnyResolver::Esplora(inner) => inner.add_terminals(consignment),
+        }
+    }
 }
 
 impl ResolveHeight for AnyResolver {

--- a/src/resolvers/mod.rs
+++ b/src/resolvers/mod.rs
@@ -27,4 +27,4 @@ pub mod esplora_blocking;
 pub mod electrum;
 
 #[cfg(any(feature = "electrum", feature = "esplora_blocking"))]
-pub use any::AnyResolver;
+pub use any::{AnyResolver, AnyResolverError};

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -105,9 +105,11 @@ pub enum RuntimeError {
     #[from(bpwallet::LoadError)]
     Bp(bpwallet::RuntimeError),
 
-    #[cfg(feature = "esplora_blocking")]
+    /// resolver error: {0}
+    #[cfg(any(feature = "electrum", feature = "esplora_blocking"))]
     #[from]
-    Esplora(esplora::Error),
+    #[display(doc_comments)]
+    ResolverError(crate::AnyResolverError),
 
     #[from]
     Yaml(serde_yaml::Error),


### PR DESCRIPTION
This PR completes support for electrum.

`rgb-runtime` now uses either electrum or esplora as a resolver, using the same rules as in `bp-wallet`/`bp-util`.

This is in draft as it depends on https://github.com/BP-WG/bp-wallet/pull/19.