### PR TITLE
feature gate serde usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1654,6 +1654,7 @@ dependencies = [
  "bp-esplora",
  "bp-std",
  "bp-wallet",
+ "cfg_eval",
  "chrono",
  "commit_verify",
  "descriptors",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,6 +86,7 @@ serde_crate = { workspace = true, optional = true }
 serde_yaml = { workspace = true, optional = true }
 serde_with = { workspace = true, optional = true }
 log = { workspace = true, optional = true }
+cfg_eval = "0.1.2"
 
 [features]
 default = ["esplora_blocking"]

--- a/src/descriptor.rs
+++ b/src/descriptor.rs
@@ -50,8 +50,8 @@ pub trait DescriptorRgb<K = XpubDerivable, V = ()>: Descriptor<K, V> {
 }
 
 #[derive(Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Debug, Display)]
-#[derive(Serialize, Deserialize)]
-#[serde(crate = "serde_crate", rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(crate = "serde_crate", rename_all = "camelCase"))]
 #[repr(u8)]
 pub enum RgbKeychain {
     #[display("0", alt = "0")]
@@ -106,15 +106,15 @@ impl From<RgbKeychain> for Keychain {
     fn from(keychain: RgbKeychain) -> Self { Keychain::from(keychain as u8) }
 }
 
-#[serde_as]
+#[cfg_attr(feature = "serde", cfg_eval::cfg_eval, serde_as)]
 #[derive(Clone, Eq, PartialEq, Debug)]
-#[derive(Serialize, Deserialize)]
-#[serde(crate = "serde_crate", rename_all = "camelCase")]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(crate = "serde_crate", rename_all = "camelCase"))]
 pub struct TapretKey<K: DeriveXOnly = XpubDerivable> {
     pub internal_key: K,
     // TODO: Allow multiple tweaks per index by introducing derivation using new Terminal trait
     // TODO: Change serde implementation for both Terminal and TapretCommitment
-    #[serde_as(as = "HashMap<serde_with::DisplayFromStr, serde_with::DisplayFromStr>")]
+    #[cfg_attr(feature = "serde", serde_as(as = "HashMap<serde_with::DisplayFromStr, serde_with::DisplayFromStr>"))]
     pub tweaks: HashMap<Terminal, TapretCommitment>,
 }
 
@@ -224,15 +224,15 @@ impl<K: DeriveXOnly> DescriptorRgb<K> for TapretKey<K> {
 }
 
 #[derive(Clone, Eq, PartialEq, Debug, From)]
-#[derive(Serialize, Deserialize)]
-#[serde(
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(
     crate = "serde_crate",
     rename_all = "camelCase",
     bound(
         serialize = "S::Compr: serde::Serialize, S::XOnly: serde::Serialize",
         deserialize = "S::Compr: serde::Deserialize<'de>, S::XOnly: serde::Deserialize<'de>"
     )
-)]
+))]
 #[non_exhaustive]
 pub enum RgbDescr<S: DeriveSet = XpubDerivable> {
     #[from]

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -24,6 +24,7 @@
 use std::collections::HashMap;
 use std::convert::Infallible;
 use std::io;
+#[cfg(feature = "serde")]
 use std::io::ErrorKind;
 use std::ops::{Deref, DerefMut};
 use std::path::PathBuf;
@@ -31,6 +32,7 @@ use std::path::PathBuf;
 use amplify::IoError;
 use bpstd::{Network, XpubDerivable};
 use bpwallet::Wallet;
+#[cfg(feature = "serde")]
 use rgbfs::StockFs;
 use rgbstd::containers::{Contract, LoadError, Transfer};
 use rgbstd::interface::{
@@ -43,7 +45,9 @@ use rgbstd::persistence::{
 use rgbstd::resolvers::ResolveHeight;
 use rgbstd::validation::{self, ResolveWitness};
 use rgbstd::{AssignmentWitness, ContractId, WitnessId, XChain, XOutpoint};
-use strict_types::encoding::{DecodeError, DeserializeError, Ident, SerializeError, TypeName};
+use strict_types::encoding::{DeserializeError, Ident, SerializeError, TypeName};
+#[cfg(feature = "serde")]
+use strict_types::encoding::DecodeError;
 
 use crate::{DescriptorRgb, RgbDescr};
 
@@ -109,6 +113,7 @@ pub enum RuntimeError {
     #[from]
     Esplora(esplora::Error),
 
+    #[cfg(feature = "serde")]
     #[from]
     Yaml(serde_yaml::Error),
 


### PR DESCRIPTION
This PR feature gates serde functionality, fixing `clippy` and build errors.

While linting the project I ran into these errors reported by `clippy --no-default-features`.
Interestingly, the errors are not reported if `clippy` is run with the `--workspace` option, which is what is used in GH Actions `Lints` workflow.

I have confirmed the errors are correct trying to build `rgb-lib` depending on `rgb-runtime` with the `serde` feature disabled. This way I get the exact same errors `clippy` reports without `--workspace`. I have also checked that it compiles and runs all tests fine when including this PR.

I think the issue with specifying `--workspace` is that dependency resolution is different. Specifically, `rgb-wallet`'s dependency on `rgb-runtime` with all enabled features, including `serde`, might be masking the errors by inadvertently enabling the `serde` feature on `rgb-runtime` even if `--no-default-features` is used.

I am quite confident this might be the case as `clippy` correctly reports the errors if either `cli` is removed from the workspace `members` or the `serde` feature is removed from `rgb-wallet`'s dependency on `rgb-runtime`.

I guess the usage of the `--workspace` option might also be the reason why some GH Actions jobs, like Build > no-default, pass instead of failing (`cargo check --no-default-features` fails without `--workspace` on `master` and passes with this PR).

I think cargo commands need to be run without `--workspace`, possibly separately for each package, in order to avoid hiding errors.