### PR TITLE
Mark as rgb-consumer only transition inputs

### DIFF
--- a/psbt/src/lib.rs
+++ b/psbt/src/lib.rs
@@ -77,10 +77,11 @@ impl RgbPsbt for Psbt {
             let contract_id = info.transition.contract_id;
             let mut inputs = info.inputs.into_inner();
             for input in self.inputs_mut() {
-                inputs.remove(&XChain::Bitcoin(input.prevout().outpoint()));
-                input
-                    .set_rgb_consumer(contract_id, info.id)
-                    .map_err(|_| EmbedError::PsbtRepeatedInputs)?;
+                if inputs.remove(&XChain::Bitcoin(input.prevout().outpoint())) {
+                    input
+                        .set_rgb_consumer(contract_id, info.id)
+                        .map_err(|_| EmbedError::PsbtRepeatedInputs)?;
+                }
             }
             if !inputs.is_empty() {
                 return Err(EmbedError::AbsentInputs);


### PR DESCRIPTION
**Description**

This PR fixes the addition of the "rgb input consumer" property only for inputs that are part of RGB transitions.

I got this bug after executing consecutive transfers, and to avoid "dust transaction", I started mixing different terminal derivations (i.e., tapret with bitcoin, opret with change, etc..)