### PR TITLE
add tapret tweak only when necessary

### DIFF
--- a/src/pay.rs
+++ b/src/pay.rs
@@ -315,13 +315,15 @@ impl Runtime {
         let contract_id = invoice.contract.ok_or(CompletionError::NoContract)?;
 
         let fascia = psbt.rgb_commit()?;
-        if let Some(output) = psbt.dbc_output::<TapretProof>() {
-            let terminal = output
-                .terminal_derivation()
-                .ok_or(CompletionError::InconclusiveDerivation)?;
-            let tapret_commitment = output.tapret_commitment()?;
-            self.wallet_mut()
-                .add_tapret_tweak(terminal, tapret_commitment)?;
+        if let (Some(_), _) = fascia.anchor.as_reduced_unsafe().as_split() {
+            if let Some(output) = psbt.dbc_output::<TapretProof>() {
+                let terminal = output
+                    .terminal_derivation()
+                    .ok_or(CompletionError::InconclusiveDerivation)?;
+                let tapret_commitment = output.tapret_commitment()?;
+                self.wallet_mut()
+                    .add_tapret_tweak(terminal, tapret_commitment)?;
+            }
         }
 
         let witness_txid = psbt.txid();


### PR DESCRIPTION
I've found a bug while doing transfers between an opret wallet (using rgb-lib) and a tapret wallet (using rgb-wallet). In detail I've:
1. issued a contract with the opret wallet
2. sent some assets from the opret to the tapret wallet
    - in witness
    - the sender defined an opret seal
3. sent some assets back from the tapret to the opret wallet
    - with a blinded UTXO
    - requesting an opret seal

The second transfer will have in input an opret seal and will define 2 seals, one opret (for the receiver) and one tapret (for the RGB change), therefore it will need to create an opret anchor.

This transfer fails (when calling the [`pay` method](https://github.com/RGB-WG/rgb/blob/master/src/pay.rs#L161)) with the error `Completion(TapretKey(NoCommitment))`.

Investigating this, I've noticed that the call to `psbt.dbc_output::<TapretProof>()` returns an p2tr output and currently it's used to decide if a tapret tweak needs to be added. But when it tries to extract the tapret commitment from that output (`let tapret_commitment = output.tapret_commitment()?;`) it fails because it's not there (since the call to `rgb_commit` created just an opret commitment). I think the issue is that the call to `dbc_output` is not enough to decide whether there is a tapret commitment that needs a tapret tweak to be added, in this case for example the method is seeing the p2tr output for the bitcoin change.

Therefore with this fix I'm protecting that code with an extra check, inspecting the `AnchorSet` of the `Fascia` to see if there's a tapret anchor. As an alternative fix I think the `rgb_commit` method could return the `CloseMethodSet` it used and then protect the addition of the tapret tweak calling `has_tapret_first`.