### PR TITLE
Support up to two bundles per witness PSBT

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1561,7 +1561,7 @@ dependencies = [
 [[package]]
 name = "rgb-core"
 version = "0.11.0-beta.5"
-source = "git+https://github.com/RGB-WG/rgb-core?branch=single-commit#9ea69c018d95fe7a3a0d991609145cabe41b9eda"
+source = "git+https://github.com/RGB-WG/rgb-core?branch=v0.11#6aa78851e1d7d474590124f45e4b819b05f24a09"
 dependencies = [
  "aluvm",
  "amplify",
@@ -1583,7 +1583,7 @@ dependencies = [
 [[package]]
 name = "rgb-invoice"
 version = "0.11.0-beta.5"
-source = "git+https://github.com/RGB-WG/rgb-std?branch=single-commit#c72159cc3d407696b66b559705c9c03da295663e"
+source = "git+https://github.com/RGB-WG/rgb-std?branch=v0.11#468200b74c2adfac054d6d15b08973a4af634d26"
 dependencies = [
  "amplify",
  "baid58",
@@ -1653,7 +1653,7 @@ dependencies = [
 [[package]]
 name = "rgb-std"
 version = "0.11.0-beta.5"
-source = "git+https://github.com/RGB-WG/rgb-std?branch=single-commit#c72159cc3d407696b66b559705c9c03da295663e"
+source = "git+https://github.com/RGB-WG/rgb-std?branch=v0.11#468200b74c2adfac054d6d15b08973a4af634d26"
 dependencies = [
  "amplify",
  "ascii-armor",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1561,7 +1561,7 @@ dependencies = [
 [[package]]
 name = "rgb-core"
 version = "0.11.0-beta.5"
-source = "git+https://github.com/RGB-WG/rgb-core?branch=asset_tags#9d193fbfc676fee6496c025f395606eea45704d6"
+source = "git+https://github.com/RGB-WG/rgb-core?branch=single-commit#9ea69c018d95fe7a3a0d991609145cabe41b9eda"
 dependencies = [
  "aluvm",
  "amplify",
@@ -1583,7 +1583,7 @@ dependencies = [
 [[package]]
 name = "rgb-invoice"
 version = "0.11.0-beta.5"
-source = "git+https://github.com/RGB-WG/rgb-std?branch=asset_tags#dbf0df4d5c8457b5d298b0a69ecb0e58b04257c1"
+source = "git+https://github.com/RGB-WG/rgb-std?branch=single-commit#c72159cc3d407696b66b559705c9c03da295663e"
 dependencies = [
  "amplify",
  "baid58",
@@ -1653,7 +1653,7 @@ dependencies = [
 [[package]]
 name = "rgb-std"
 version = "0.11.0-beta.5"
-source = "git+https://github.com/RGB-WG/rgb-std?branch=asset_tags#dbf0df4d5c8457b5d298b0a69ecb0e58b04257c1"
+source = "git+https://github.com/RGB-WG/rgb-std?branch=single-commit#c72159cc3d407696b66b559705c9c03da295663e"
 dependencies = [
  "amplify",
  "ascii-armor",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,6 +106,6 @@ bp-std = { git = "https://github.com/BP-WG/bp-std", branch = "v0.11" }
 psbt = { git = "https://github.com/BP-WG/bp-std", branch = "v0.11" }
 descriptors = { git = "https://github.com/BP-WG/bp-std", branch = "v0.11" }
 bp-wallet = { git = "https://github.com/BP-WG/bp-wallet", branch = "v0.11" }
-rgb-core = { git = "https://github.com/RGB-WG/rgb-core", branch = "single-commit" }
-rgb-std = { git = "https://github.com/RGB-WG/rgb-std", branch = "single-commit" }
-rgb-invoice = { git = "https://github.com/RGB-WG/rgb-std", branch = "single-commit" }
+rgb-core = { git = "https://github.com/RGB-WG/rgb-core", branch = "v0.11" }
+rgb-std = { git = "https://github.com/RGB-WG/rgb-std", branch = "v0.11" }
+rgb-invoice = { git = "https://github.com/RGB-WG/rgb-std", branch = "v0.11" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,6 +106,6 @@ bp-std = { git = "https://github.com/BP-WG/bp-std", branch = "v0.11" }
 psbt = { git = "https://github.com/BP-WG/bp-std", branch = "v0.11" }
 descriptors = { git = "https://github.com/BP-WG/bp-std", branch = "v0.11" }
 bp-wallet = { git = "https://github.com/BP-WG/bp-wallet", branch = "v0.11" }
-rgb-core = { git = "https://github.com/RGB-WG/rgb-core", branch = "asset_tags" }
-rgb-std = { git = "https://github.com/RGB-WG/rgb-std", branch = "asset_tags" }
-rgb-invoice = { git = "https://github.com/RGB-WG/rgb-std", branch = "asset_tags" }
+rgb-core = { git = "https://github.com/RGB-WG/rgb-core", branch = "single-commit" }
+rgb-std = { git = "https://github.com/RGB-WG/rgb-std", branch = "single-commit" }
+rgb-invoice = { git = "https://github.com/RGB-WG/rgb-std", branch = "single-commit" }

--- a/cli/src/command.rs
+++ b/cli/src/command.rs
@@ -937,7 +937,7 @@ impl Exec for RgbArgs {
                 for id in runtime.witness_ids()? {
                     fs::write(
                         format!("{root_dir}/stash/anchors/{id}.yaml"),
-                        serde_yaml::to_string(&runtime.anchor(id)?)?,
+                        serde_yaml::to_string(&runtime.anchors(id)?)?,
                     )?;
                 }
                 for id in runtime.extension_ids()? {


### PR DESCRIPTION
Opret and tapret combined result in two bundles in witness transaction. This PR solves the way such situations are handled, also using fixes on double-commitment schemes from RGB core and standard libraries.

Counterpart to:
- https://github.com/RGB-WG/rgb-core/pull/232
- https://github.com/RGB-WG/rgb-std/pull/180