### PR TITLE
cli: fix transfer print psbt version

### DIFF
--- a/cli/src/command.rs
+++ b/cli/src/command.rs
@@ -763,8 +763,8 @@ impl Exec for RgbArgs {
                         psbt.encode(ver, &mut psbt_file)?;
                     }
                     None => match ver {
-                        PsbtVer::V0 => println!("{psbt}"),
-                        PsbtVer::V2 => println!("{psbt:#}"),
+                        PsbtVer::V0 => println!("{psbt:0}"),
+                        PsbtVer::V2 => println!("{psbt:2}"),
                     },
                 }
                 Some(runtime.into_stock())


### PR DESCRIPTION
Description:
    The display implementation of Psbt does not use `{:#}(formatter.alternate())` to determine the psbt version. All printing here is the V2 version of psbt.