### PR TITLE
resolver: implement check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,47 +124,48 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.13"
+version = "0.6.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d96bd03f33fe50a863e394ee9718a706f988b9079b20c3784fb726e7678b62fb"
+checksum = "418c75fa768af9c03be99d17643f93f79bbba589895012a80e3452a19ddda15b"
 dependencies = [
  "anstyle",
  "anstyle-parse",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
+ "is_terminal_polyfill",
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
+checksum = "038dfcf04a5feb68e9c60b21c9625a54c2c0616e79b72b0fd87075a056ae1d1b"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c"
+checksum = "c03a11a9034d92058ceb6ee011ce58af4a9bf61491aa7e1e59ecd24bd40d22d4"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
+checksum = "a64c907d4e79225ac72e2a354c9ce84d50ebb4586dee56c82b3ee73004f537f5"
 dependencies = [
  "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.2"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
+checksum = "61a38449feb7068f52bb06c12759005cf459ee52bb4adc1d5a7c4322d716fb19"
 dependencies = [
  "anstyle",
  "windows-sys 0.52.0",
@@ -323,7 +324,7 @@ dependencies = [
 [[package]]
 name = "bp-consensus"
 version = "0.11.0-beta.5"
-source = "git+https://github.com/BP-WG/bp-core?branch=develop#970147b7cfa3dd3013ceec5bc6eacaea7c0d7bb9"
+source = "git+https://github.com/BP-WG/bp-core?branch=develop#289f1d31fd404b76b1ac04edb1024bdbe4386416"
 dependencies = [
  "amplify",
  "chrono",
@@ -337,7 +338,7 @@ dependencies = [
 [[package]]
 name = "bp-core"
 version = "0.11.0-beta.5"
-source = "git+https://github.com/BP-WG/bp-core?branch=develop#970147b7cfa3dd3013ceec5bc6eacaea7c0d7bb9"
+source = "git+https://github.com/BP-WG/bp-core?branch=develop#289f1d31fd404b76b1ac04edb1024bdbe4386416"
 dependencies = [
  "amplify",
  "bp-consensus",
@@ -355,7 +356,7 @@ dependencies = [
 [[package]]
 name = "bp-dbc"
 version = "0.11.0-beta.5"
-source = "git+https://github.com/BP-WG/bp-core?branch=develop#970147b7cfa3dd3013ceec5bc6eacaea7c0d7bb9"
+source = "git+https://github.com/BP-WG/bp-core?branch=develop#289f1d31fd404b76b1ac04edb1024bdbe4386416"
 dependencies = [
  "amplify",
  "base85",
@@ -430,7 +431,7 @@ dependencies = [
 [[package]]
 name = "bp-seals"
 version = "0.11.0-beta.5"
-source = "git+https://github.com/BP-WG/bp-core?branch=develop#970147b7cfa3dd3013ceec5bc6eacaea7c0d7bb9"
+source = "git+https://github.com/BP-WG/bp-core?branch=develop#289f1d31fd404b76b1ac04edb1024bdbe4386416"
 dependencies = [
  "amplify",
  "baid64",
@@ -567,9 +568,9 @@ checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
 
 [[package]]
 name = "commit_encoding_derive"
@@ -1145,6 +1146,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
+
+[[package]]
 name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1520,7 +1527,7 @@ dependencies = [
 [[package]]
 name = "rgb-core"
 version = "0.11.0-beta.5"
-source = "git+https://github.com/RGB-WG/rgb-core?branch=develop#f0469333a36abcb70dff6667938fc1eae438e1d2"
+source = "git+https://github.com/RGB-WG/rgb-core?branch=develop#b34b2c7b96f669fb8bc7145ec7094cb65d8bbdf3"
 dependencies = [
  "aluvm",
  "amplify",
@@ -1541,7 +1548,7 @@ dependencies = [
 [[package]]
 name = "rgb-interfaces"
 version = "0.11.0-beta.6"
-source = "git+https://github.com/RGB-WG/rgb-interfaces?branch=develop#1fb09cb8c23e062c8a059fb9afec7f2f135440ae"
+source = "git+https://github.com/RGB-WG/rgb-interfaces?branch=develop#d688b6a98f547f24b7edc7f96b30b6c1e94893ef"
 dependencies = [
  "aluvm",
  "amplify",
@@ -1557,7 +1564,7 @@ dependencies = [
 [[package]]
 name = "rgb-invoice"
 version = "0.11.0-beta.5"
-source = "git+https://github.com/RGB-WG/rgb-std?branch=develop#75fb0dd098574957478bf6d4bf3533abc325efb5"
+source = "git+https://github.com/RGB-WG/rgb-std?branch=develop#47413dfdda70dcf7963a9b4b03f406e374e15fae"
 dependencies = [
  "amplify",
  "baid64",
@@ -1617,7 +1624,7 @@ dependencies = [
 [[package]]
 name = "rgb-std"
 version = "0.11.0-beta.5"
-source = "git+https://github.com/RGB-WG/rgb-std?branch=develop#75fb0dd098574957478bf6d4bf3533abc325efb5"
+source = "git+https://github.com/RGB-WG/rgb-std?branch=develop#47413dfdda70dcf7963a9b4b03f406e374e15fae"
 dependencies = [
  "aluvm",
  "amplify",
@@ -1887,18 +1894,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.199"
+version = "1.0.200"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c9f6e76df036c77cd94996771fb40db98187f096dd0b9af39c6c6e452ba966a"
+checksum = "ddc6f9cc94d67c0e21aaf7eda3a010fd3af78ebf6e096aa6e2e13c79749cce4f"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.199"
+version = "1.0.200"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11bd257a6541e141e42ca6d24ae26f7714887b47e89aa739099104c7e4d3b7fc"
+checksum = "856f046b9400cee3c8c94ed572ecdb752444c24528c035cd35882aad6f492bcb"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/cli/src/args.rs
+++ b/cli/src/args.rs
@@ -120,11 +120,13 @@ impl RgbArgs {
     }
 
     pub fn resolver(&self) -> Result<AnyResolver, WalletError> {
-        match (&self.resolver.esplora, &self.resolver.electrum) {
+        let resolver = match (&self.resolver.esplora, &self.resolver.electrum) {
             (None, Some(url)) => AnyResolver::electrum_blocking(url),
             (Some(url), None) => AnyResolver::esplora_blocking(url),
             _ => unreachable!("clap is broken"),
         }
-        .map_err(WalletError::Resolver)
+        .map_err(WalletError::Resolver)?;
+        resolver.check(self.general.network)?;
+        Ok(resolver)
     }
 }

--- a/src/resolvers/any.rs
+++ b/src/resolvers/any.rs
@@ -24,6 +24,7 @@
 use std::collections::HashMap;
 
 use bp::Tx;
+use bpstd::Network;
 use rgbstd::containers::Consignment;
 use rgbstd::resolvers::ResolveHeight;
 use rgbstd::validation::{ResolveWitness, WitnessResolverError};
@@ -32,6 +33,7 @@ use rgbstd::{WitnessAnchor, XWitnessId, XWitnessTx};
 use crate::{Txid, WitnessOrd, XChain};
 
 pub trait RgbResolver {
+    fn check(&self, network: Network, expected_block_hash: String) -> Result<(), String>;
     fn resolve_height(&mut self, txid: Txid) -> Result<WitnessAnchor, String>;
     fn resolve_pub_witness(&self, txid: Txid) -> Result<Tx, Option<String>>;
 }
@@ -63,6 +65,17 @@ impl AnyResolver {
             ),
             terminal_txes: Default::default(),
         })
+    }
+
+    pub fn check(&self, network: Network) -> Result<(), String> {
+        let expected_block_hash = match network {
+            Network::Mainnet => "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f",
+            Network::Testnet3 => "000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943",
+            Network::Signet => "00000008819873e925422c1ff0f99f7cc9bbb232af63a077a480a3633bee1ef6",
+            Network::Regtest => "0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206",
+        }
+        .to_string();
+        self.inner.check(network, expected_block_hash)
     }
 
     pub fn add_terminals<const TYPE: bool>(&mut self, consignment: &Consignment<TYPE>) {

--- a/src/resolvers/electrum_blocking.rs
+++ b/src/resolvers/electrum_blocking.rs
@@ -24,7 +24,7 @@
 use std::iter;
 
 use bp::ConsensusDecode;
-use bpstd::{Tx, Txid};
+use bpstd::{Network, Tx, Txid};
 use electrum::{Client, ElectrumApi, Error, Param};
 use rgbstd::{WitnessAnchor, WitnessOrd, WitnessPos, XWitnessId};
 
@@ -37,6 +37,36 @@ macro_rules! check {
 }
 
 impl RgbResolver for Client {
+    fn check(&self, network: Network, expected_block_hash: String) -> Result<(), String> {
+        // check the electrum server is for the correct network
+        let block_hash = check!(self.block_header(0)).block_hash().to_string();
+        if expected_block_hash != block_hash {
+            return Err(s!("resolver is for a network different from the wallet's one"));
+        }
+        // check the electrum server has the required functionality (verbose
+        // transactions)
+        let txid = match network {
+            Network::Mainnet => "33e794d097969002ee05d336686fc03c9e15a597c1b9827669460fac98799036",
+            Network::Testnet3 => "5e6560fd518aadbed67ee4a55bdc09f19e619544f5511e9343ebba66d2f62653",
+            Network::Signet => "8153034f45e695453250a8fb7225a5e545144071d8ed7b0d3211efa1f3c92ad8",
+            Network::Regtest => "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b",
+        };
+        if let Err(e) = self.raw_call("blockchain.transaction.get", vec![
+            Param::String(txid.to_string()),
+            Param::Bool(true),
+        ]) {
+            if !e
+                .to_string()
+                .contains("genesis block coinbase is not considered an ordinary transaction")
+            {
+                return Err(s!(
+                    "verbose transactions are unsupported by the provided electrum service"
+                ));
+            }
+        }
+        Ok(())
+    }
+
     fn resolve_height(&mut self, txid: Txid) -> Result<WitnessAnchor, String> {
         let mut witness_anchor = WitnessAnchor {
             witness_ord: WitnessOrd::OffChain,

--- a/src/resolvers/esplora_blocking.rs
+++ b/src/resolvers/esplora_blocking.rs
@@ -20,7 +20,7 @@
 // limitations under the License.
 
 use bp::Tx;
-use bpstd::Txid;
+use bpstd::{Network, Txid};
 use esplora::{BlockingClient, Error};
 use rgbstd::{WitnessAnchor, WitnessOrd, WitnessPos};
 
@@ -28,6 +28,15 @@ use super::RgbResolver;
 use crate::XWitnessId;
 
 impl RgbResolver for BlockingClient {
+    fn check(&self, _network: Network, expected_block_hash: String) -> Result<(), String> {
+        // check the esplora server is for the correct network
+        let block_hash = self.block_hash(0)?.to_string();
+        if expected_block_hash != block_hash {
+            return Err(s!("resolver is for a network different from the wallet's one"));
+        }
+        Ok(())
+    }
+
     fn resolve_height(&mut self, txid: Txid) -> Result<WitnessAnchor, String> {
         let status = self.tx_status(&txid)?;
         let ord = match status


### PR DESCRIPTION
Closes https://github.com/RGB-WG/rgb/issues/193.

This PR implements a `check` method for the resolvers, which makes sure the provided resolver is for the correct network and, for the electrum server it checks the necessary functionality (verbose transactions support) is there. I've taken inspiration from what we do in rgb-lib.

Note: in rust-bitcoin there's a method of the block header, `block_hash`, that easily gives you the block hash for the header. I didn't find this method in the header from bp so for simplicity I've just implemented the hash calculation in the electrum check method, but @dr-orlovsky if you agree I can implement the method and then subsitute that here, let me know.

