### PR TITLE
report fungible values in human-readable form

### DIFF
--- a/cli/src/command.rs
+++ b/cli/src/command.rs
@@ -542,7 +542,7 @@ impl Exec for RgbArgs {
                         for allocation in allocations {
                             println!(
                                 "    value={}, utxo={}, witness={} {}",
-                                allocation.state,
+                                allocation.state.value(),
                                 allocation.seal,
                                 allocation.witness,
                                 filter.comment(allocation.seal.to_outpoint())


### PR DESCRIPTION
As discussed in #209, this PR converts fungible allocation values into human-readable integers.