### PR TITLE
keep only blocking feature for bp-esplora

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ bp-core = "0.11.0-beta.6"
 bp-seals = "0.11.0-beta.6"
 bp-std = "0.11.0-beta.6"
 bp-electrum = "0.11.0-beta.6"
-bp-esplora = "0.11.0-beta.6"
+bp-esplora = { version = "0.11.0-beta.6", default-features = false, features = ["blocking"] }
 descriptors = "0.11.0-beta.6"
 psbt = { version = "0.11.0-beta.6", features = ["client-side-validation"] }
 bp-wallet = { version = "0.11.0-beta.6.1" }


### PR DESCRIPTION
This PR removes the default features from bp-esplora, only keeping `blocking`.
Conbined with https://github.com/BP-WG/bp-wallet/pull/42, this has the effect of dropping lots of dependencies that were in fact unused.