### PR TITLE
Support new witness filtering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -521,9 +521,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cc"
-version = "1.1.6"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aba8f4e9906c7ce3c73463f62a7f0c65183ada1a2d47e397cc8810827f9694f"
+checksum = "26a5c3fd7bfa1ce3897a3a3501d362b2d87b7f2583ebcb4a949ec25911025cbc"
 dependencies = [
  "jobserver",
  "libc",
@@ -1123,7 +1123,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1366,7 +1366,7 @@ checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 [[package]]
 name = "rgb-core"
 version = "0.11.0-beta.6"
-source = "git+https://github.com/RGB-WG/rgb-core?branch=mining#5a824a3c973c28285d116049a43c15bb26d9c7e6"
+source = "git+https://github.com/RGB-WG/rgb-core?branch=mining#fa31db7d22d06b6fa5152b51666edc3eb3135447"
 dependencies = [
  "aluvm",
  "amplify",
@@ -1387,7 +1387,7 @@ dependencies = [
 [[package]]
 name = "rgb-interfaces"
 version = "0.11.0-beta.6"
-source = "git+https://github.com/RGB-WG/rgb-interfaces.git?branch=mining#a3630d2ea460eb74ab7c64965d6d37a6b73f3f2a"
+source = "git+https://github.com/RGB-WG/rgb-interfaces.git?branch=mining#ccf17daed04a94888341a89a578d5f1085e6133c"
 dependencies = [
  "aluvm",
  "amplify",
@@ -1403,7 +1403,7 @@ dependencies = [
 [[package]]
 name = "rgb-invoice"
 version = "0.11.0-beta.6"
-source = "git+https://github.com/RGB-WG/rgb-std?branch=mining#120e01957af037fa95e1fa611ee90235b48e6645"
+source = "git+https://github.com/RGB-WG/rgb-std?branch=mining#a2ff52cb393ee67f4a8d9d7226d6ae788a5e657a"
 dependencies = [
  "amplify",
  "baid64",
@@ -1464,7 +1464,7 @@ dependencies = [
 [[package]]
 name = "rgb-std"
 version = "0.11.0-beta.6"
-source = "git+https://github.com/RGB-WG/rgb-std?branch=mining#120e01957af037fa95e1fa611ee90235b48e6645"
+source = "git+https://github.com/RGB-WG/rgb-std?branch=mining#a2ff52cb393ee67f4a8d9d7226d6ae788a5e657a"
 dependencies = [
  "aluvm",
  "amplify",
@@ -1684,11 +1684,12 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.120"
+version = "1.0.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e0d21c9a8cae1235ad58a00c11cb40d4b1e5c784f1ef2c537876ed6ffd8b7c5"
+checksum = "4ab380d7d9f22ef3f21ad3e6c1ebe8e4fc7a2000ccba2e4d71fc96f15b2cb609"
 dependencies = [
  "itoa",
+ "memchr",
  "ryu",
  "serde",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,9 +116,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.14"
+version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418c75fa768af9c03be99d17643f93f79bbba589895012a80e3452a19ddda15b"
+checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -131,33 +131,33 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "038dfcf04a5feb68e9c60b21c9625a54c2c0616e79b72b0fd87075a056ae1d1b"
+checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c03a11a9034d92058ceb6ee011ce58af4a9bf61491aa7e1e59ecd24bd40d22d4"
+checksum = "eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad186efb764318d35165f1758e7dcef3b10628e26d41a44bc5550652e6804391"
+checksum = "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a"
 dependencies = [
  "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61a38449feb7068f52bb06c12759005cf459ee52bb4adc1d5a7c4322d716fb19"
+checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
 dependencies = [
  "anstyle",
  "windows-sys 0.52.0",
@@ -165,9 +165,9 @@ dependencies = [
 
 [[package]]
 name = "arrayref"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b4930d2cb77ce62f89ee5d5289b4ac049559b1c45539271f5ed4fdc7db34545"
+checksum = "9d151e35f61089500b617991b791fc8bfd237ae50cd5950803758a179b41e67a"
 
 [[package]]
 name = "arrayvec"
@@ -205,9 +205,9 @@ checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8a47f2fb521b70c11ce7369a6c5fa4bd6af7e5d62ec06303875bafe7c6ba245"
+checksum = "4ae74d9bd0a7530e8afd1770739ad34b36838829d6ad61818f9230f683f5ad77"
 dependencies = [
  "aws-lc-sys",
  "mirai-annotations",
@@ -217,9 +217,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2927c7af777b460b7ccd95f8b67acd7b4c04ec8896bf0c8e80ba30523cffc057"
+checksum = "2e89b6941c2d1a7045538884d6e760ccfffdf8e1ffc2613d8efa74305e1f3752"
 dependencies = [
  "bindgen",
  "cc",
@@ -282,7 +282,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.71",
+ "syn 2.0.72",
  "which",
 ]
 
@@ -415,7 +415,7 @@ dependencies = [
  "byteorder",
  "libc",
  "log",
- "rustls 0.23.11",
+ "rustls",
  "serde",
  "serde_json",
  "sha2",
@@ -521,9 +521,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cc"
-version = "1.1.5"
+version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "324c74f2155653c90b04f25b2a47a8a631360cb908f92a772695f430c7e31052"
+checksum = "2aba8f4e9906c7ce3c73463f62a7f0c65183ada1a2d47e397cc8810827f9694f"
 dependencies = [
  "jobserver",
  "libc",
@@ -572,9 +572,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.9"
+version = "4.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64acc1846d54c1fe936a78dc189c34e28d3f5afc348403f28ecf53660b9b8462"
+checksum = "35723e6a11662c2afb578bcf0b88bf6ea8e21282a953428f240574fcc3a2b5b3"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -582,9 +582,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.9"
+version = "4.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fb8393d67ba2e7bfaf28a23458e4e2b543cc73a99595511eb207fdb8aede942"
+checksum = "49eb96cbfa7cfa35017b7cd548c75b14c3118c98b423041d70562665e07fb0fa"
 dependencies = [
  "anstream",
  "anstyle",
@@ -594,21 +594,21 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.8"
+version = "4.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bac35c6dafb060fd4d275d9a4ffae97917c13a6327903a8be2153cd964f7085"
+checksum = "5d029b67f89d30bbb547c89fd5161293c0aec155fc691d7924b64550662db93e"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
+checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
 
 [[package]]
 name = "cmake"
@@ -621,9 +621,9 @@ dependencies = [
 
 [[package]]
 name = "colorchoice"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
+checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
 
 [[package]]
 name = "colored"
@@ -742,7 +742,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -753,7 +753,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -822,9 +822,9 @@ checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "env_filter"
-version = "0.1.0"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a009aa4810eb158359dda09d0c87378e4bbb89b5a801f016885a4707ba24f7ea"
+checksum = "4f2c92ceda6ceec50f43169f9ee8424fe2db276791afde7b2cd8bc084cb376ab"
 dependencies = [
  "log",
  "regex",
@@ -832,9 +832,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.3"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b35839ba51819680ba087cd351788c9a3c476841207e0b8cee0b04722343b9"
+checksum = "e13fa619b91fb2381732789fc5de83b45675e882f66623b7d8cb4f643017018d"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1061,9 +1061,9 @@ dependencies = [
 
 [[package]]
 name = "is_terminal_polyfill"
-version = "1.70.0"
+version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
@@ -1082,9 +1082,9 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "jobserver"
-version = "0.1.31"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2b099aaa34a9751c5bf0878add70444e1ed2dd73f347be99003d4577277de6e"
+checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
 dependencies = [
  "libc",
 ]
@@ -1118,12 +1118,12 @@ checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "libloading"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e310b3a6b5907f99202fcdb4960ff45b93735d7c7d96b760fcff8db2dc0e103d"
+checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1255,7 +1255,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f12335488a2f3b0a83b14edad48dca9879ce89b2edd10e80237e4e852dd645e"
 dependencies = [
  "proc-macro2",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -1366,7 +1366,7 @@ checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 [[package]]
 name = "rgb-core"
 version = "0.11.0-beta.6"
-source = "git+https://github.com/RGB-WG/rgb-core?branch=mining#0f94cc05643b93769466cdd8e74a7a85d4b30a9c"
+source = "git+https://github.com/RGB-WG/rgb-core?branch=mining#5a824a3c973c28285d116049a43c15bb26d9c7e6"
 dependencies = [
  "aluvm",
  "amplify",
@@ -1387,7 +1387,7 @@ dependencies = [
 [[package]]
 name = "rgb-interfaces"
 version = "0.11.0-beta.6"
-source = "git+https://github.com/RGB-WG/rgb-interfaces.git?branch=master#05166e951f9b4b0663114d1e248f840ffbfe8f23"
+source = "git+https://github.com/RGB-WG/rgb-interfaces.git?branch=mining#a3630d2ea460eb74ab7c64965d6d37a6b73f3f2a"
 dependencies = [
  "aluvm",
  "amplify",
@@ -1403,7 +1403,7 @@ dependencies = [
 [[package]]
 name = "rgb-invoice"
 version = "0.11.0-beta.6"
-source = "git+https://github.com/RGB-WG/rgb-std?branch=mining#8e398941253fc5426492d97add74ed9fbfcd9223"
+source = "git+https://github.com/RGB-WG/rgb-std?branch=mining#21f9b206697b08f8473092618d9801c197ed576a"
 dependencies = [
  "amplify",
  "baid64",
@@ -1454,7 +1454,6 @@ dependencies = [
  "descriptors",
  "indexmap 2.2.6",
  "log",
- "rgb-interfaces",
  "rgb-psbt",
  "rgb-std",
  "serde",
@@ -1465,7 +1464,7 @@ dependencies = [
 [[package]]
 name = "rgb-std"
 version = "0.11.0-beta.6"
-source = "git+https://github.com/RGB-WG/rgb-std?branch=mining#8e398941253fc5426492d97add74ed9fbfcd9223"
+source = "git+https://github.com/RGB-WG/rgb-std?branch=mining#21f9b206697b08f8473092618d9801c197ed576a"
 dependencies = [
  "aluvm",
  "amplify",
@@ -1556,27 +1555,14 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.22.4"
+version = "0.23.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
-dependencies = [
- "log",
- "ring",
- "rustls-pki-types",
- "rustls-webpki",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "rustls"
-version = "0.23.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4828ea528154ae444e5a642dbb7d5623354030dc9822b83fd9bb79683c7399d0"
+checksum = "c58f8c84392efc0a126acce10fa59ff7b3d2ac06ab451a33f2741989b806b044"
 dependencies = [
  "aws-lc-rs",
  "log",
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -1591,9 +1577,9 @@ checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.5"
+version = "0.102.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9a6fccd794a42c2c105b513a2f62bc3fd8f3ba57a4593677ceb0bd035164d78"
+checksum = "8e6b52d4fda176fd835fdc55a835d4a89b8499cad995885a21149d5ad62f852e"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -1693,7 +1679,7 @@ checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -1709,9 +1695,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.6"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79e674e01f999af37c49f70a6ede167a8a60b2503e56c5599532a65baa5969a0"
+checksum = "eb5b1b31579f3811bf615c144393417496f152e12ac8b7663bf664f4a815306d"
 dependencies = [
  "serde",
 ]
@@ -1753,7 +1739,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -1901,9 +1887,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.71"
+version = "2.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b146dcf730474b4bcd16c311627b31ede9ab149045db4d6088b3becaea046462"
+checksum = "dc4b9b9bf2add8093d3f2c0204471e951b2285580335de42f9d2534f3ae7a8af"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1912,22 +1898,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.62"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2675633b1499176c2dff06b0856a27976a8f9d436737b4cf4f312d4d91d8bbb"
+checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.62"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d20468752b09f49e909e55a5d338caa8bedf615594e9d80bc4c565d30faf798c"
+checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -1978,9 +1964,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "toml"
-version = "0.8.14"
+version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f49eb2ab21d2f26bd6db7bf383edc527a7ebaee412d17af4d40fdccd442f335"
+checksum = "81967dd0dd2c1ab0bc3468bd7caecc32b8a4aa47d0c8c695d8c2b2108168d62c"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -1990,18 +1976,18 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.6"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4badfd56924ae69bcc9039335b2e017639ce3f9b001c393c1b2d1ef846ce2cbf"
+checksum = "f8fb9f64314842840f1d940ac544da178732128f1c78c21772e876579e0da1db"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.15"
+version = "0.22.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d59a3a72298453f564e2b111fa896f8d07fabb36f51f06d7e875fc5e0b5a3ef1"
+checksum = "8d9f8729f5aea9562aac1cc0441f5d6de3cff1ee0c5d67293eeca5eb36ee7c16"
 dependencies = [
  "indexmap 2.2.6",
  "serde",
@@ -2051,17 +2037,16 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"
-version = "2.9.7"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d11a831e3c0b56e438a28308e7c810799e3c118417f342d30ecec080105395cd"
+checksum = "72139d247e5f97a3eff96229a7ae85ead5328a39efe76f8bf5a06313d505b6ea"
 dependencies = [
  "base64",
  "flate2",
  "log",
  "once_cell",
- "rustls 0.22.4",
+ "rustls",
  "rustls-pki-types",
- "rustls-webpki",
  "serde",
  "serde_json",
  "socks",
@@ -2088,9 +2073,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "version_check"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vesper-lang"
@@ -2129,7 +2114,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
  "wasm-bindgen-shared",
 ]
 
@@ -2163,7 +2148,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2196,7 +2181,7 @@ checksum = "b7f89739351a2e03cb94beb799d47fb2cac01759b40ec441f7de39b00cbf7ef0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -2408,9 +2393,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.6.13"
+version = "0.6.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59b5e5f6c299a3c7890b876a2a587f3115162487e704907d9b6cd29473052ba1"
+checksum = "b480ae9340fc261e6be3e95a1ba86d54ae3f9171132a73ce8d4bbaf68339507c"
 dependencies = [
  "memchr",
 ]
@@ -2432,5 +2417,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1366,7 +1366,7 @@ checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 [[package]]
 name = "rgb-core"
 version = "0.11.0-beta.6"
-source = "git+https://github.com/RGB-WG/rgb-core?branch=master#84892fd826f6f7805b076e70cba467b85c1eb8f7"
+source = "git+https://github.com/RGB-WG/rgb-core?branch=mining#0f94cc05643b93769466cdd8e74a7a85d4b30a9c"
 dependencies = [
  "aluvm",
  "amplify",
@@ -1403,7 +1403,7 @@ dependencies = [
 [[package]]
 name = "rgb-invoice"
 version = "0.11.0-beta.6"
-source = "git+https://github.com/RGB-WG/rgb-std?branch=txid#f584d104a2672f546135ede6ddea15607b33e479"
+source = "git+https://github.com/RGB-WG/rgb-std?branch=mining#8e398941253fc5426492d97add74ed9fbfcd9223"
 dependencies = [
  "amplify",
  "baid64",
@@ -1465,7 +1465,7 @@ dependencies = [
 [[package]]
 name = "rgb-std"
 version = "0.11.0-beta.6"
-source = "git+https://github.com/RGB-WG/rgb-std?branch=txid#f584d104a2672f546135ede6ddea15607b33e479"
+source = "git+https://github.com/RGB-WG/rgb-std?branch=mining#8e398941253fc5426492d97add74ed9fbfcd9223"
 dependencies = [
  "aluvm",
  "amplify",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1123,7 +1123,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -1403,7 +1403,7 @@ dependencies = [
 [[package]]
 name = "rgb-invoice"
 version = "0.11.0-beta.6"
-source = "git+https://github.com/RGB-WG/rgb-std?branch=mining#21f9b206697b08f8473092618d9801c197ed576a"
+source = "git+https://github.com/RGB-WG/rgb-std?branch=mining#120e01957af037fa95e1fa611ee90235b48e6645"
 dependencies = [
  "amplify",
  "baid64",
@@ -1464,7 +1464,7 @@ dependencies = [
 [[package]]
 name = "rgb-std"
 version = "0.11.0-beta.6"
-source = "git+https://github.com/RGB-WG/rgb-std?branch=mining#21f9b206697b08f8473092618d9801c197ed576a"
+source = "git+https://github.com/RGB-WG/rgb-std?branch=mining#120e01957af037fa95e1fa611ee90235b48e6645"
 dependencies = [
  "aluvm",
  "amplify",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,6 @@ descriptors = { workspace = true }
 bp-wallet = { workspace = true }
 rgb-std = { workspace = true }
 rgb-psbt = { workspace = true }
-rgb-interfaces = { workspace = true }
 indexmap = { workspace = true }
 chrono = { workspace = true }
 serde_crate = { workspace = true, optional = true }
@@ -105,4 +104,4 @@ bp-wallet = { git = "https://github.com/BP-WG/bp-wallet", branch = "master" }
 rgb-core = { git = "https://github.com/RGB-WG/rgb-core", branch = "mining" }
 rgb-invoice = { git = "https://github.com/RGB-WG/rgb-std", branch = "mining" }
 rgb-std = { git = "https://github.com/RGB-WG/rgb-std", branch = "mining" }
-rgb-interfaces = { git = "https://github.com/RGB-WG/rgb-interfaces.git", branch = "master" }
+rgb-interfaces = { git = "https://github.com/RGB-WG/rgb-interfaces.git", branch = "mining" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,7 +102,7 @@ descriptors = { git = "https://github.com/BP-WG/bp-std", branch = "master" }
 psbt = { git = "https://github.com/BP-WG/bp-std", branch = "master" }
 bp-std = { git = "https://github.com/BP-WG/bp-std", branch = "master" }
 bp-wallet = { git = "https://github.com/BP-WG/bp-wallet", branch = "master" }
-rgb-core = { git = "https://github.com/RGB-WG/rgb-core", branch = "master" }
-rgb-invoice = { git = "https://github.com/RGB-WG/rgb-std", branch = "txid" }
-rgb-std = { git = "https://github.com/RGB-WG/rgb-std", branch = "txid" }
+rgb-core = { git = "https://github.com/RGB-WG/rgb-core", branch = "mining" }
+rgb-invoice = { git = "https://github.com/RGB-WG/rgb-std", branch = "mining" }
+rgb-std = { git = "https://github.com/RGB-WG/rgb-std", branch = "mining" }
 rgb-interfaces = { git = "https://github.com/RGB-WG/rgb-interfaces.git", branch = "master" }

--- a/cli/src/command.rs
+++ b/cli/src/command.rs
@@ -46,6 +46,7 @@ use rgb::{
     RgbKeychain, RgbWallet, StateType, TransferParams, WalletError, WalletProvider, XChain,
     XOutpoint, XOutputSeal,
 };
+use rgbstd::containers::ConsignmentExt;
 use serde_crate::{Deserialize, Serialize};
 use strict_types::encoding::{FieldName, TypeName};
 use strict_types::StrictVal;
@@ -345,7 +346,7 @@ impl Exec for RgbArgs {
                 standard: Some(IfaceStandard::Rgb20),
             } => {
                 let stock = self.rgb_stock()?;
-                for info in stock.contracts_by::<Rgb20>()? {
+                for info in stock.contracts_by::<Rgb20<_>>()? {
                     print!("{info}");
                 }
             }
@@ -353,7 +354,7 @@ impl Exec for RgbArgs {
                 standard: Some(IfaceStandard::Rgb21),
             } => {
                 let stock = self.rgb_stock()?;
-                for info in stock.contracts_by::<Rgb21>()? {
+                for info in stock.contracts_by::<Rgb21<_>>()? {
                     print!("{info}");
                 }
             }
@@ -361,7 +362,7 @@ impl Exec for RgbArgs {
                 standard: Some(IfaceStandard::Rgb25),
             } => {
                 let stock = self.rgb_stock()?;
-                for info in stock.contracts_by::<Rgb25>()? {
+                for info in stock.contracts_by::<Rgb25<_>>()? {
                     print!("{info}");
                 }
             }
@@ -488,7 +489,8 @@ impl Exec for RgbArgs {
 
                 let contract = stock.contract_iface(*contract_id, tn!(iface.to_owned()))?;
 
-                let filter = match self.rgb_wallet_from_stock(&config, stock) {
+                // TODO: Remove clone
+                let filter = match self.rgb_wallet_from_stock(&config, stock.clone()) {
                     Ok(wallet) if *all => Filter::WalletAll(wallet),
                     Ok(wallet) => Filter::Wallet(wallet),
                     Err(_) => {
@@ -1011,10 +1013,10 @@ impl Exec for RgbArgs {
                 // TODO: Add sigs debugging
 
                 // State
-                for (id, history) in stock.as_state_provider().debug_history() {
+                for (id, state) in stock.as_state_provider().debug_contracts() {
                     fs::write(
                         format!("{root_dir}/state/{id:-}.yaml"),
-                        serde_yaml::to_string(history)?,
+                        serde_yaml::to_string(state)?,
                     )?;
                 }
 

--- a/cli/src/command.rs
+++ b/cli/src/command.rs
@@ -1013,6 +1013,10 @@ impl Exec for RgbArgs {
                 // TODO: Add sigs debugging
 
                 // State
+                fs::write(
+                    format!("{root_dir}/state/witnesses.yaml"),
+                    serde_yaml::to_string(stock.as_state_provider().debug_witnesses())?,
+                )?;
                 for (id, state) in stock.as_state_provider().debug_contracts() {
                     fs::write(
                         format!("{root_dir}/state/{id:-}.yaml"),

--- a/src/indexers/any.rs
+++ b/src/indexers/any.rs
@@ -26,9 +26,10 @@ use std::collections::HashMap;
 use bp::Tx;
 use bpstd::Network;
 use rgbstd::containers::Consignment;
-use rgbstd::resolvers::ResolveHeight;
+use rgbstd::resolvers::ResolveWitnessAnchor;
 use rgbstd::validation::{ResolveWitness, WitnessResolverError};
-use rgbstd::{WitnessAnchor, XWitnessId, XWitnessTx};
+use rgbstd::vm::WitnessAnchor;
+use rgbstd::{XWitnessId, XWitnessTx};
 
 use crate::{Txid, WitnessOrd, XChain};
 
@@ -96,7 +97,7 @@ impl AnyResolver {
             consignment
                 .bundles
                 .iter()
-                .filter_map(|bw| bw.pub_witness.maybe_map_ref(|w| w.tx.clone()))
+                .filter_map(|bw| bw.pub_witness.maybe_map_ref(|w| w.tx().cloned()))
                 .filter_map(|tx| match tx {
                     XChain::Bitcoin(tx) => Some(tx),
                     XChain::Liquid(_) | XChain::Other(_) => None,
@@ -106,8 +107,8 @@ impl AnyResolver {
     }
 }
 
-impl ResolveHeight for AnyResolver {
-    fn resolve_height(&mut self, witness_id: XWitnessId) -> Result<WitnessAnchor, String> {
+impl ResolveWitnessAnchor for AnyResolver {
+    fn resolve_witness_anchor(&mut self, witness_id: XWitnessId) -> Result<WitnessAnchor, String> {
         let XWitnessId::Bitcoin(txid) = witness_id else {
             return Err(format!("{} is not supported as layer 1 network", witness_id.layer1()));
         };

--- a/src/indexers/any.rs
+++ b/src/indexers/any.rs
@@ -96,7 +96,7 @@ impl AnyResolver {
             consignment
                 .bundles
                 .iter()
-                .filter_map(|bw| bw.pub_witness.maybe_map_ref(|w| w.tx().cloned()))
+                .filter_map(|bw| bw.pub_witness.maybe_map_ref(|w| w.tx.clone()))
                 .filter_map(|tx| match tx {
                     XChain::Bitcoin(tx) => Some(tx),
                     XChain::Liquid(_) | XChain::Other(_) => None,
@@ -114,7 +114,7 @@ impl ResolveHeight for AnyResolver {
 
         if self.terminal_txes.contains_key(&txid) {
             return Ok(WitnessAnchor {
-                witness_ord: WitnessOrd::OffChain,
+                witness_ord: WitnessOrd::offchain(0),
                 witness_id,
             });
         }

--- a/src/indexers/electrum_blocking.rs
+++ b/src/indexers/electrum_blocking.rs
@@ -70,7 +70,7 @@ impl RgbResolver for Client {
 
     fn resolve_height(&mut self, txid: Txid) -> Result<WitnessAnchor, String> {
         let mut witness_anchor = WitnessAnchor {
-            witness_ord: WitnessOrd::OffChain,
+            witness_ord: WitnessOrd::offchain(1),
             witness_id: XWitnessId::Bitcoin(txid),
         };
 

--- a/src/indexers/electrum_blocking.rs
+++ b/src/indexers/electrum_blocking.rs
@@ -26,7 +26,8 @@ use std::iter;
 use bp::ConsensusDecode;
 use bpstd::{Network, Tx, Txid};
 use electrum::{Client, ElectrumApi, Error, Param};
-use rgbstd::{WitnessAnchor, WitnessOrd, WitnessPos, XWitnessId};
+use rgbstd::vm::WitnessAnchor;
+use rgbstd::{WitnessOrd, WitnessPos, XWitnessId};
 
 use super::RgbResolver;
 

--- a/src/indexers/electrum_blocking.rs
+++ b/src/indexers/electrum_blocking.rs
@@ -71,7 +71,7 @@ impl RgbResolver for Client {
 
     fn resolve_height(&mut self, txid: Txid) -> Result<WitnessAnchor, String> {
         let mut witness_anchor = WitnessAnchor {
-            witness_ord: WitnessOrd::offchain(1),
+            witness_ord: WitnessOrd::Archived,
             witness_id: XWitnessId::Bitcoin(txid),
         };
 
@@ -104,6 +104,10 @@ impl RgbResolver for Client {
                 .and_then(|x| u32::try_from(x).ok())
                 .ok_or(Error::InvalidResponse(tx_details.clone()))
         );
+        if confirmations == 0 {
+            witness_anchor.witness_ord = WitnessOrd::OffChain { priority: 1 };
+            return Ok(witness_anchor);
+        }
         let block_time = check!(
             tx_details
                 .get("blocktime")

--- a/src/indexers/esplora_blocking.rs
+++ b/src/indexers/esplora_blocking.rs
@@ -22,7 +22,8 @@
 use bp::Tx;
 use bpstd::{Network, Txid};
 use esplora::{BlockingClient, Error};
-use rgbstd::{WitnessAnchor, WitnessOrd, WitnessPos};
+use rgbstd::vm::WitnessAnchor;
+use rgbstd::{WitnessOrd, WitnessPos};
 
 use super::RgbResolver;
 use crate::XWitnessId;

--- a/src/indexers/esplora_blocking.rs
+++ b/src/indexers/esplora_blocking.rs
@@ -46,7 +46,7 @@ impl RgbResolver for BlockingClient {
             Some((h, t)) => {
                 WitnessOrd::OnChain(WitnessPos::new(h, t as i64).ok_or(Error::InvalidServerData)?)
             }
-            None => WitnessOrd::OffChain,
+            None => WitnessOrd::offchain(1),
         };
         Ok(WitnessAnchor {
             witness_ord: ord,

--- a/src/indexers/esplora_blocking.rs
+++ b/src/indexers/esplora_blocking.rs
@@ -47,7 +47,8 @@ impl RgbResolver for BlockingClient {
             Some((h, t)) => {
                 WitnessOrd::OnChain(WitnessPos::new(h, t as i64).ok_or(Error::InvalidServerData)?)
             }
-            None => WitnessOrd::offchain(1),
+            // TODO: Figure out how to detect mempool transactions
+            None => WitnessOrd::Archived,
         };
         Ok(WitnessAnchor {
             witness_ord: ord,

--- a/src/indexers/mempool_blocking.rs
+++ b/src/indexers/mempool_blocking.rs
@@ -22,7 +22,7 @@
 use bp::Tx;
 use bpstd::{Network, Txid};
 use esplora::{BlockingClient, Config, Error};
-use rgbstd::WitnessAnchor;
+use rgbstd::vm::WitnessAnchor;
 
 use super::RgbResolver;
 

--- a/src/pay.rs
+++ b/src/pay.rs
@@ -111,7 +111,7 @@ where Self::Descr: DescriptorRgb<K>
     ) -> Result<(Psbt, PsbtMeta, Transfer), PayError> {
         let (mut psbt, meta) = self.construct_psbt_rgb(stock, invoice, params)?;
         // ... here we pass PSBT around signers, if necessary
-        let transfer = self.transfer(stock, invoice, &mut psbt)?;
+        let transfer = self.transfer(stock, invoice, &mut psbt, 2)?;
         Ok((psbt, meta, transfer))
     }
 
@@ -278,6 +278,7 @@ where Self::Descr: DescriptorRgb<K>
         stock: &mut Stock<S, H, P>,
         invoice: &RgbInvoice,
         psbt: &mut Psbt,
+        priority: u32,
     ) -> Result<Transfer, CompletionError> {
         let contract_id = invoice.contract.ok_or(CompletionError::NoContract)?;
 
@@ -311,7 +312,9 @@ where Self::Descr: DescriptorRgb<K>
             Beneficiary::BlindedSeal(seal) => (vec![XChain::Bitcoin(seal)], vec![]),
         };
 
-        stock.consume_fascia(fascia).map_err(|e| e.to_string())?;
+        stock
+            .consume_fascia(fascia, priority)
+            .map_err(|e| e.to_string())?;
         let transfer = stock
             .transfer(contract_id, beneficiary2, beneficiary1)
             .map_err(|e| e.to_string())?;

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -159,6 +159,6 @@ where W::Descr: DescriptorRgb<K>
         invoice: &RgbInvoice,
         psbt: &mut Psbt,
     ) -> Result<Transfer, CompletionError> {
-        self.wallet.transfer(&mut self.stock, invoice, psbt)
+        self.wallet.transfer(&mut self.stock, invoice, psbt, 2)
     }
 }

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -131,7 +131,7 @@ where W::Descr: DescriptorRgb<K>
             .contract_iface(contract_id, iref)
             .map_err(|e| e.to_string())?;
         Ok(contract
-            .fungible_ops::<AmountChange>(state_name, wallet.filter(), wallet.filter())
+            .fungible_ops::<AmountChange>(state_name, wallet.filter())
             .map_err(|e| e.to_string())?)
     }
 

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -20,9 +20,9 @@
 // limitations under the License.
 
 use bpwallet::{Save, Wallet};
-use rgbstd::interface::{OutpointFilter, WitnessFilter};
+use rgbstd::interface::OutpointFilter;
 
-use crate::{AssignmentWitness, DescriptorRgb, WalletProvider, XChain, XOutpoint, XWitnessId};
+use crate::{DescriptorRgb, WalletProvider, XChain, XOutpoint};
 
 pub struct WalletWrapper<'a, K, D: DescriptorRgb<K>>(pub &'a Wallet<K, D>)
 where Wallet<K, D>: Save;
@@ -42,16 +42,5 @@ where Wallet<K, D>: Save
         self.0
             .outpoints()
             .any(|outpoint| XChain::Bitcoin(outpoint) == *output)
-    }
-}
-
-impl<'a, K, D: DescriptorRgb<K>> WitnessFilter for WalletWrapper<'a, K, D>
-where Wallet<K, D>: Save
-{
-    fn include_witness(&self, witness: impl Into<AssignmentWitness>) -> bool {
-        let witness = witness.into();
-        self.0
-            .txids()
-            .any(|txid| AssignmentWitness::Present(XWitnessId::Bitcoin(txid)) == witness)
     }
 }


### PR DESCRIPTION
Part of the epic:
- https://github.com/RGB-WG/rgb-core/pull/263
- https://github.com/RGB-WG/rgb-std/pull/241
- https://github.com/RGB-WG/rgb-interfaces/pull/10
- https://github.com/RGB-WG/rgb-schemata/pull/45

rgb command-line tool if used with `--sync` argument now not just synchronizes the wallet outputs, but also refreshes mining status of witness transactions. We have one additional command-line argument added (`--from-height`) which allows to control from which height the synchronization should start (speeding it up).