### PR TITLE
RgbResolver: add Send trait bound

### DIFF
--- a/src/indexers/any.rs
+++ b/src/indexers/any.rs
@@ -34,7 +34,7 @@ use crate::{Txid, XChain};
 
 // We need to repeat methods of `WitnessResolve` trait here to avoid making
 // wrappers around resolver types. TODO: Use wrappers instead
-pub trait RgbResolver {
+pub trait RgbResolver: Send {
     fn check(&self, network: Network, expected_block_hash: String) -> Result<(), String>;
     fn resolve_pub_witness(&self, txid: Txid) -> Result<Option<Tx>, String>;
     fn resolve_pub_witness_ord(&self, txid: Txid) -> Result<WitnessOrd, String>;


### PR DESCRIPTION
This PR adds the `Send` trait bound to the `inner` field of the `AnyResolver` struct.

Without this change when trying to create an rgb-lib wallet (which contains an instance of `AnyResolver`) in `tokio::task::spawn_blocking` we receive an error, saying that
```
`(dyn rgb::indexers::any::RgbResolver + 'static)` cannot be sent between threads safely
```

This was not happening with beta 5, where `AnyResolver` was an enum