### PR TITLE
Fix: RGB Descriptor YAML Serialization for Nested Enums

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1527,6 +1527,7 @@ dependencies = [
  "serde",
  "serde_yaml",
  "strict_types",
+ "toml",
  "wasm-bindgen",
  "wasm-bindgen-test",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ indexmap = "2.9.0"
 chrono = { version = "0.4.41", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
 serde_yaml = "0.9.19"
+toml = "0.8.22"
 log = { version = "0.4", features = ["max_level_trace", "release_max_level_debug"] }
 
 [package]
@@ -65,6 +66,9 @@ chrono = { workspace = true }
 serde = { workspace = true, optional = true }
 serde_yaml = { workspace = true, optional = true }
 log = { workspace = true, optional = true }
+
+[dev-dependencies]
+toml.workspace = true
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = "0.2"

--- a/src/descriptor.rs
+++ b/src/descriptor.rs
@@ -227,6 +227,7 @@ impl<K: DeriveSet<Compr = K, XOnly = K> + DeriveCompr + DeriveXOnly> Descriptor<
     )
 )]
 pub struct RgbDescr<K: DeriveSet = XpubDerivable> {
+    #[cfg_attr(feature = "serde", serde(with = "serde_yaml::with::singleton_map_recursive"))]
     deriver: RgbDeriver<K>,
     seals: SealDescr,
     noise: Bytes32,

--- a/src/descriptor.rs
+++ b/src/descriptor.rs
@@ -327,3 +327,45 @@ impl<K: DeriveSet<Compr = K, XOnly = K> + DeriveCompr + DeriveXOnly> Descriptor<
         self.deriver.taproot_witness(keysigs)
     }
 }
+
+#[cfg(test)]
+mod test {
+    use core::str::FromStr;
+
+    use bpstd::Wpkh;
+
+    use super::*;
+
+    #[test]
+    fn descr_serde() {
+        let s = "[643a7adc/86'/1'/0']tpubDCNiWHaiSkgnQjuhsg9kjwaUzaxQjUcmhagvYzqQ3TYJTgFGJstVaqnu4yhtFktBhCVFmBNLQ5sN53qKzZbMksm3XEyGJsEhQPfVZdWmTE2/<0;1;9;10>/*";
+        let xpub = XpubDerivable::from_str(s).unwrap();
+        let descr = RgbDescr::<XpubDerivable>::new_unfunded(Wpkh::from(xpub), [0u8; 32]);
+
+        let yaml = serde_yaml::to_string(&descr).unwrap();
+        let toml = toml::to_string(&descr).unwrap();
+        let descr2: RgbDescr<XpubDerivable> = serde_yaml::from_str(&yaml).unwrap();
+        let descr3: RgbDescr<XpubDerivable> = toml::from_str(&toml).unwrap();
+
+        assert_eq!(descr.to_string(), descr2.to_string());
+        assert_eq!(descr.to_string(), descr3.to_string());
+        assert_eq!(yaml, "\
+deriver:
+  opretOnly:
+    wpkh: '[643a7adc/86h/1h/0h]tpubDCNiWHaiSkgnQjuhsg9kjwaUzaxQjUcmhagvYzqQ3TYJTgFGJstVaqnu4yhtFktBhCVFmBNLQ5sN53qKzZbMksm3XEyGJsEhQPfVZdWmTE2/<0;1;9;10>/*'
+seals: []
+noise: '0000000000000000000000000000000000000000000000000000000000000000'
+nonce: 0
+");
+        assert_eq!(
+            toml,
+            r#"seals = []
+noise = "0000000000000000000000000000000000000000000000000000000000000000"
+nonce = 0
+
+[deriver.opretOnly]
+wpkh = "[643a7adc/86h/1h/0h]tpubDCNiWHaiSkgnQjuhsg9kjwaUzaxQjUcmhagvYzqQ3TYJTgFGJstVaqnu4yhtFktBhCVFmBNLQ5sN53qKzZbMksm3XEyGJsEhQPfVZdWmTE2/<0;1;9;10>/*"
+"#
+        );
+    }
+}


### PR DESCRIPTION
# Fix: RGB Descriptor YAML Serialization for Nested Enums

## Problem

RGB wallet descriptor serialization fails with WPKH descriptor types due to `serde_yaml` limitation with nested enums.

### Error
```
Persistence error: serializing nested enums in YAML is not supported yet
```

## Root Cause

The `RgbDescr` struct contains nested enum structures:

```rust
pub struct RgbDescr<K: DeriveSet = XpubDerivable> {
    deriver: RgbDeriver<K>,  // enum containing StdDescr<K> enum
    // ...
}
```

When using WPKH descriptors, this creates:
`RgbDeriver::OpretOnly(StdDescr::Wpkh(...))` - a nested enum structure that `serde_yaml` cannot serialize.

## Solution

Add `singleton_map_recursive` serde attribute to the `deriver` field:

```rust
pub struct RgbDescr<K: DeriveSet = XpubDerivable> {
    #[cfg_attr(feature = "serde", serde(with = "serde_yaml::with::singleton_map_recursive"))]
    deriver: RgbDeriver<K>,
    seals: SealDescr,
    noise: Bytes32,
    nonce: u64,
}
```

## References

- [serde-yaml issue #363](https://github.com/dtolnay/serde-yaml/issues/363)
- [singleton_map_recursive docs](https://docs.rs/serde_yaml/latest/serde_yaml/with/singleton_map_recursive/index.html) 