### PR TITLE
make runtime's wallet as public

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -60,7 +60,7 @@ pub trait WalletUpdater {
     fn update<I: Indexer>(&mut self, indexer: &I) -> MayError<(), Vec<I::Error>>;
 }
 
-pub struct RgbRuntime<Wallet, Sp>(RgbWallet<Wallet, Sp>)
+pub struct RgbRuntime<Wallet, Sp>(pub RgbWallet<Wallet, Sp>)
 where
     Wallet: PsbtConstructor + WalletProvider + WalletUpdater,
     Sp: Stockpile,


### PR DESCRIPTION
the wallet has a unbind method, so we need a way to move out the wallet from the runtime to unbind the wallet