### PR TITLE
Update RGB library dependencies to latest versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ To use the library from other rust code add dependency to the `Cargo.toml` file:
 
 ```toml
 [dependencies]
-rgb-std = "0.11.0-beta.7" # use the latest version
-rgb-runtime = "0.11.0-beta.7" # use the latest version
+rgb-std = "0.12.0-rc.3" # use the latest version
+rgb-runtime = "0.12.0-rc.3" # use the latest version
 ```
 
 ## Using the demo script


### PR DESCRIPTION
I noticed that the readme states the latest dependencies version dependency is 0.11.0-beta.7. However, the actual current version is 0.12.0-rc.3, and there hasn't been a new version released for 5 months. Therefore, it is recommended to modify the description of the dependencies version to 0.12.0-rc.3.